### PR TITLE
Add static options_data describing the options for a UI.

### DIFF
--- a/src/Fhaculty/Graph/Uml/ClassDiagramBuilder.php
+++ b/src/Fhaculty/Graph/Uml/ClassDiagramBuilder.php
@@ -31,20 +31,33 @@ class ClassDiagramBuilder
      */
     private $graph;
 
-    private $options = array(
-        // whether to only show methods/properties that are actually defined in this class (and not those merely inherited from base)
-        'only-self'   => true,
-        // whether to also show private methods/properties
-        'show-private' => false,
-        // whether to also show protected methods/properties
-        'show-protected' => true,
-        // whether to show class constants as readonly static variables (or just omit them completely)
-        'show-constants' => true,
+    static $options_data = array(
+        'only-self'   => array(
+            'default' => true,
+            'description' => 'whether to only show methods/properties that are actually defined in this class (and not those merely inherited from base)',
+        ),
+        'show-private' => array(
+            'default' => false,
+            'description' => 'whether to also show private methods/properties',
+        ),
+        'show-protected' => array(
+            'default' => true,
+            'description' => 'whether to also show protected methods/properties',
+        ),
+        'show-constants' => array(
+            'default' => true,
+            'description' => 'whether to show class constants as readonly static variables (or just omit them completely)',
+        ),
     );
+
+    private $options = array();
 
     public function __construct(Graph $graph)
     {
         $this->graph = $graph;
+        foreach(self::$options_data as $key => $data) {
+          $this->options[$key] = $data['default'];
+        }
     }
 
     public function setOption($name, $flag)


### PR DESCRIPTION
I need the options avalable through a UI (Drupal).

With the patch done below I get them like done in the (show off image :p)

![add-documented-options-2](https://f.cloud.github.com/assets/371014/1819191/33caff7e-706f-11e3-8358-6b6b29097710.png)
- [ ] Are the descriptions good enough?
- [ ] Do we need more meta data regarding the options?

Within Drupal I run something like the code below to build the needed UI

``` php
  function getMetas() {
    $meta = ClassDiagramBuilder::$options_data;;

    $meta['generate-script'] = array(
      'description' => 'Adds the script for the Class Diagram',
      'default' => FALSE,
    );
    $meta['generate-image'] = array(
      'description' => 'Adds the image for the Class Diagram',
      'default' => TRUE,
    );

    foreach ($meta as $key => &$data) {
      if (is_bool($data['default'])) {
        if ($data['default']) {
          $data['example'] = "$key:0 or 1 (default)";
        }
        else {
          $data['example'] = "$key:1 or 0 (default)";
        }
      }
      else {
        $data['example'] = "$key:" . $data['default'];
      }
    }
    return $meta;
  }
```
