### PR TITLE
Remove transitive interfaces (implicitly inherited ones)

### DIFF
--- a/src/Fhaculty/Graph/Uml/ClassDiagramBuilder.php
+++ b/src/Fhaculty/Graph/Uml/ClassDiagramBuilder.php
@@ -560,7 +560,7 @@ class ClassDiagramBuilder
         // remove each interface already implemented by any of the inherited interfaces
         foreach ($interfaces as $if) {
             foreach ($if->getInterfaceNames() as $in) {
-                //unset($interfaces[$in]);
+                unset($interfaces[$in]);
             }
         }
 

--- a/src/Fhaculty/Graph/Uml/ClassDiagramBuilder.php
+++ b/src/Fhaculty/Graph/Uml/ClassDiagramBuilder.php
@@ -88,7 +88,7 @@ class ClassDiagramBuilder
             $vertex->createEdgeTo($parentVertex)->setLayoutAttribute('arrowhead', 'empty');
         }
 
-        foreach ($reflection->getInterfaces() as $interface) {
+        foreach ($this->getInterfaces($reflection) as $interface) {
             try {
                 $parentVertex = $this->graph->getVertex($interface->getName());
             } catch (Exception $ignore) {
@@ -542,5 +542,28 @@ class ClassDiagramBuilder
     private function escape($id)
     {
         return preg_replace('/([^\\w])/u', '\\\\$1', str_replace(array("\r", "\n", "\t"), array('\\r', '\\n', '\\t'), $id));
+    }
+
+    private function getInterfaces(ReflectionClass $reflection)
+    {
+        // a list of all interfaces implemented explicitly or implicitly
+        $interfaces = $reflection->getInterfaces();
+
+        // remove each interface already implemented by the parent class (if any)
+        $parent = $reflection->getParentClass();
+        if ($parent) {
+            foreach ($parent->getInterfaceNames() as $in) {
+                unset($interfaces[$in]);
+            }
+        }
+
+        // remove each interface already implemented by any of the inherited interfaces
+        foreach ($interfaces as $if) {
+            foreach ($if->getInterfaceNames() as $in) {
+                //unset($interfaces[$in]);
+            }
+        }
+
+        return $interfaces;
     }
 }


### PR DESCRIPTION
Before:
![uml-old](https://f.cloud.github.com/assets/776829/1820564/3acf0174-70f3-11e3-8d50-1b29ebffaada.png)

After:
![uml-new](https://f.cloud.github.com/assets/776829/1820563/3aa83bca-70f3-11e3-8173-f1e64d584031.png)

Fixes #10.
Not sure how this relates to #17.
