### PR TITLE
Allow adding same classes multiple times

### DIFF
--- a/src/Fhaculty/Graph/Uml/ClassDiagramBuilder.php
+++ b/src/Fhaculty/Graph/Uml/ClassDiagramBuilder.php
@@ -80,7 +80,7 @@ class ClassDiagramBuilder
             $class = ltrim($class, '\\');
             $reflection = new ReflectionClass($class);
         }
-        $vertex = $this->graph->createVertex($class);
+        $vertex = $this->graph->createVertex($class, TRUE);
         if ($this->options['add-parents']) {
             $parent = $reflection->getParentClass();
             if ($parent) {

--- a/tests/Graph/Uml/ClassDiagramBuilderTest.php
+++ b/tests/Graph/Uml/ClassDiagramBuilderTest.php
@@ -18,12 +18,7 @@ class ClassDiagramBuilderTest extends TestCase
     }
 
     /**
-     * Test to show failing code
-     *
      * Adding a sub-class (Edge\Directed) also automatically adds its parent (Edge\Base).
-     * So trying to add the parent (Edge\Base) again fails because of a duplicate class name.
-     *
-     * @expectedException RuntimeException
      */
     public function testChildParentFail()
     {


### PR DESCRIPTION
Fixes #2 

As discussed in #2 I still don't get why this PR is not valid. So let's talk code :p

My Drupal users may type

```
[classdiagram
\Drupal\Component\Plugin\ContextAwarePluginBase
\Drupal\Core\Plugin\ContextAwarePluginBase
\Drupal\Component\Plugin\PluginBase
]
```

and without this patch this results in

```
ID must be unique
```

which by no means is solvable for my Graph API module.

With this PR we get this beautiful UML
![no-id-must-unique-awesomeness-2](https://f.cloud.github.com/assets/371014/1965586/0341e188-82bc-11e3-8395-5b34e9c9da1c.png)

(This PR saves me a lot of hairs)
